### PR TITLE
ci: update gemini-cli version to latest for evals CI pipeline

### DIFF
--- a/evals/model_config.yaml
+++ b/evals/model_config.yaml
@@ -18,6 +18,7 @@ env:
   GOOGLE_CLOUD_PROJECT: "${GOOGLE_CLOUD_PROJECT}"
   GOOGLE_CLOUD_LOCATION: "global"
   GOOGLE_GENAI_USE_VERTEXAI: "true"
+  GEMINI_CLI_TRUST_WORKSPACE: "true"
 setup:
   extensions:
     # Points to the symlink created in cloudbuild.yaml to match the extension ID

--- a/evals/model_config.yaml
+++ b/evals/model_config.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-gemini_cli_version: "@google/gemini-cli@0.38.1"
+gemini_cli_version: "@google/gemini-cli@latest"
 generator: gemini_cli
 env:
   GOOGLE_CLOUD_PROJECT: "${GOOGLE_CLOUD_PROJECT}"


### PR DESCRIPTION
### 💡 Added `GEMINI_CLI_TRUST_WORKSPACE: "true"`

**Context:** Recent versions of `gemini-cli` introduced a workspace trust security check (similar to Git's `safe.directory`). 

**Reason for change:** In automated environments like Cloud Build (`/workspace`) and EvalBench sandboxes (`.venv/fake_home`), the CLI flags the dynamic directory as untrusted. This causes evaluations to fail immediately with a 0% completion rate because it refuses to load extensions or run tool calls. 

Setting `GEMINI_CLI_TRUST_WORKSPACE: "true"` explicitly bypasses this verification check, ensuring successful test and pipeline execution.